### PR TITLE
add fuzz testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,16 +4,16 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: ['1.13', '1.14', '1.15', '1.16', '1.17']
+        go-version: ['1.13', '1.14', '1.15', '1.16', '1.17', '1.18', '1.19']
         platform: [ubuntu-latest, macos-latest, windows-latest]
       fail-fast: false
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go-version }}
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Test
         run: go test -race ./...

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -1,0 +1,55 @@
+//go:build go1.18
+// +build go1.18
+
+package base100
+
+import (
+	"bytes"
+	"testing"
+	"unicode/utf8"
+)
+
+func FuzzEncode(f *testing.F) {
+	var fuzzcases = [][]byte{
+		[]byte("Hello, world"),
+		[]byte("Hello, world\n"),
+		[]byte("\nHello, world"),
+		[]byte(""),
+		[]byte(" "),
+		[]byte("\n"),
+		[]byte("\r\n"),
+		[]byte("!12345"),
+		[]byte("제주도"),
+	}
+
+	for _, tc := range fuzzcases {
+		f.Add(tc)
+	}
+
+	f.Fuzz(func(t *testing.T, orig []byte) {
+		encoded := make([]byte, EncodedLen(len(orig)))
+		Encode(encoded, orig)
+		if got, want := len(encoded), EncodedLen(len(orig)); got != want {
+			t.Errorf("encoded is %d bytes, but EncodedLen predicted %d", got, want)
+		}
+		if !utf8.Valid(encoded) { // encoded version should always be valid utf8
+			t.Errorf("Encode produced invalid UTF-8 %q", encoded)
+		}
+
+		decoded := make([]byte, DecodedLen(len(encoded)))
+		n, err := Decode(decoded, encoded)
+		if err != nil {
+			t.Errorf("Decode returned an error: %v", err)
+		}
+		if got, want := len(decoded), n; got != want {
+			t.Errorf("dst is %d bytes, but Decode wrote %d", got, want)
+		}
+		if got, want := len(decoded), DecodedLen(len(encoded)); got != want {
+			t.Errorf("dst is %d bytes, but DecodedLen predicted %d", got, want)
+		}
+
+		if !bytes.Equal(orig, decoded) {
+			t.Errorf("original: %q, decoded: %q", orig, decoded)
+		}
+	})
+}


### PR DESCRIPTION
Fuzz testing via new integrated fuzzer in go1.18, nice!  Ran for 30 minutes on go1.18-beta1 and didn't find any issues.

Will integrate once go1.18 is released and can integrate into CI (seed fuzz tests will always run), opening this PR for now to keep track and in case I want to play with this more in the meantime.